### PR TITLE
Fix build script in OS X

### DIFF
--- a/build
+++ b/build
@@ -4,9 +4,9 @@ mkdir temp
 cp chrome.manifest temp
 cp install.rdf temp
 cp icon.png temp
-cp chrome temp -r
-cp components temp -r
-cp defaults temp -r
+cp -r chrome temp
+cp -r components temp
+cp -r defaults temp
 
 cd temp
 
@@ -17,7 +17,7 @@ while read LINE; do
     fi
     LINE1=`echo $LINE | grep -oE "^[^=]+"`
     LINE2=`echo $LINE | grep -oE "[^=]+$"`
-    sed "s|\$$LINE1|$LINE2|g" -i `find . -type f -exec grep -Iq . {} \; -and -print`
+    sed -i.bak "s|\$$LINE1|$LINE2|g" `find . -type f -exec grep -Iq . {} \; -and -print`
     eval "$LINE1=\"$LINE2\""
 done < "../config.txt"
 

--- a/build
+++ b/build
@@ -17,7 +17,7 @@ while read LINE; do
     fi
     LINE1=`echo $LINE | grep -oE "^[^=]+"`
     LINE2=`echo $LINE | grep -oE "[^=]+$"`
-    sed -i.bak "s|\$$LINE1|$LINE2|g" `find . -type f -exec grep -Iq . {} \; -and -print`
+    sed -i '' "s|\$$LINE1|$LINE2|g" `find . -type f -exec grep -Iq . {} \; -and -print`
     eval "$LINE1=\"$LINE2\""
 done < "../config.txt"
 


### PR DESCRIPTION
In some platforms (like OS X) the `sed` command needs the parameter `-i` as `-i.bak`. Also, seems like OS X is strict about the order of the parameters in `cp` command.
